### PR TITLE
Implement Boot receiver for autostart of ListenService on boot

### DIFF
--- a/RILDefender-App/app/src/main/AndroidManifest.xml
+++ b/RILDefender-App/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <application
         android:allowBackup="true"
@@ -28,6 +30,19 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name=".BootReceiver"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.RECEIVE_BOOT_COMPLETED" >
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </receiver>
+
         <activity
             android:name=".UI.AlertActivity"
             android:exported="false"

--- a/RILDefender-App/app/src/main/java/com/seclab/rildefender/BootReceiver.java
+++ b/RILDefender-App/app/src/main/java/com/seclab/rildefender/BootReceiver.java
@@ -1,0 +1,21 @@
+package com.seclab.rildefender;
+
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ComponentName;
+
+import com.seclab.rildefender.UI.ListenService;
+import com.seclab.rildefender.UI.SettingsActivity;
+
+public class BootReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
+            Intent i = new Intent(context, ListenService.class);
+            context.startService(i);
+        }
+    }
+}


### PR DESCRIPTION
After reboot, to enable service, a user must start the application. To address that, implement boot receiver to start automatically. 